### PR TITLE
Adds city filtering functionality

### DIFF
--- a/Cities/Domain/Models/Filter.swift
+++ b/Cities/Domain/Models/Filter.swift
@@ -1,0 +1,22 @@
+//
+//  Filter.swift
+//  Cities
+//
+//  Created by Manuel Rodríguez Sebastián on 2/7/25.
+//
+
+enum Filter: String, CaseIterable, Identifiable {
+    case all
+    case favorites
+    
+    var id: Self { self }
+    
+    var localizedValue: String {
+        switch self {
+        case .all:
+            return "filter_all"
+        case .favorites:
+            return "filte_favorites"
+        }
+    }
+}

--- a/Cities/Localizable.xcstrings
+++ b/Cities/Localizable.xcstrings
@@ -68,7 +68,6 @@
       }
     },
     "filter_button" : {
-      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/Cities/Localizable.xcstrings
+++ b/Cities/Localizable.xcstrings
@@ -33,6 +33,57 @@
         }
       }
     },
+    "filte_favorites" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favorites"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favoritos"
+          }
+        }
+      }
+    },
+    "filter_all" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todos"
+          }
+        }
+      }
+    },
+    "filter_button" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filter"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filtrar"
+          }
+        }
+      }
+    },
     "Lat: %.2f" : {
       "localizations" : {
         "en" : {

--- a/Cities/Presentation/Screens/List/View/CityListView.swift
+++ b/Cities/Presentation/Screens/List/View/CityListView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct CityListView: View {
     @State private var searchText: String = ""
+    @State private var filter: Filter = .all
     @StateObject private var viewModel = CityListViewModel()
     
     var body: some View {
@@ -57,7 +58,22 @@ private extension CityListView {
             prompt: "search_city_prompt"
         )
         .onChange(of: searchText) { searchText in
-            viewModel.searchCities(searchText)
+            Task { await viewModel.searchCities(searchText) }
+        }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Menu {
+                    ForEach(Filter.allCases) { option in
+                        Button {
+                            filter = option
+                        } label: {
+                            Label(option.localizedValue, systemImage: filter == option ? "checkmark" : "")
+                        }
+                    }
+                } label: {
+                    Label("filter_button", systemImage: "line.3.horizontal.decrease.circle")
+                }
+            }
         }
     }
 }

--- a/Cities/Presentation/Screens/List/View/CityListView.swift
+++ b/Cities/Presentation/Screens/List/View/CityListView.swift
@@ -60,6 +60,9 @@ private extension CityListView {
         .onChange(of: searchText) { searchText in
             Task { await viewModel.searchCities(searchText) }
         }
+        .onChange(of: filter) { filter in
+            Task { await viewModel.applyFilter(filter) }
+        }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Menu {

--- a/Cities/Utils/Extensions/Array+Extension.swift
+++ b/Cities/Utils/Extensions/Array+Extension.swift
@@ -1,0 +1,16 @@
+//
+//  Array+Extension.swift
+//  Cities
+//
+//  Created by Manuel Rodríguez Sebastián on 2/7/25.
+//
+
+extension Array {
+    func chunked(into size: Int) -> [[Element]] {
+        guard size > 0 else { return [self] }
+        return stride(from: 0, to: self.count, by: size).map { start in
+            let end = Swift.min(start + size, self.count)
+            return Array(self[start..<end])
+        }
+    }
+}

--- a/CitiesTests/Presentation/Screens/ViewModels/CityListViewModelTests.swift
+++ b/CitiesTests/Presentation/Screens/ViewModels/CityListViewModelTests.swift
@@ -216,4 +216,40 @@ final class CityListViewModelTests: XCTestCase {
         // Then
         XCTAssertNotNil(sut.errorMessage)
     }
+    
+    @MainActor
+    func testApplyFilterAll() async throws {
+        // Given
+        let cities: [CityRenderModel] = [
+            .makeDummy(country: "NL", name: "Amsterdam", id: 1, coordinates: .init(latitude: 0, longitude: 0), isFavorite: true),
+            .makeDummy(country: "FR", name: "Paris", id: 2, coordinates: .init(latitude: 0, longitude: 0), isFavorite: false),
+            .makeDummy(country: "US", name: "Paris", id: 3, coordinates: .init(latitude: 0, longitude: 0), isFavorite: false)
+        ]
+        getCitiesUseCaseMock.result = .success(cities)
+        
+        // When
+        await sut.fetchCities()
+        await sut.applyFilter(.all)
+        
+        XCTAssertFalse(sut.filteredCities.isEmpty)
+        XCTAssertEqual(sut.filteredCities.count, cities.count)
+    }
+    
+    @MainActor
+    func testApplyFilterFavorites() async throws {
+        // Given
+        let cities: [CityRenderModel] = [
+            .makeDummy(country: "NL", name: "Amsterdam", id: 1, coordinates: .init(latitude: 0, longitude: 0), isFavorite: true),
+            .makeDummy(country: "FR", name: "Paris", id: 2, coordinates: .init(latitude: 0, longitude: 0), isFavorite: false),
+            .makeDummy(country: "US", name: "Paris", id: 3, coordinates: .init(latitude: 0, longitude: 0), isFavorite: false)
+        ]
+        getCitiesUseCaseMock.result = .success(cities)
+        
+        // When
+        await sut.fetchCities()
+        await sut.applyFilter(.favorites)
+        
+        XCTAssertFalse(sut.filteredCities.isEmpty)
+        XCTAssertEqual(sut.filteredCities.count, 1)
+    }
 }


### PR DESCRIPTION
This PR introduces filtering capabilities to the city list screen.

- Implements a `Filter` enum to represent different filter options (All, Favorites).
- Adds a filter menu to the navigation bar, allowing users to select a filter.
- Updates the `CityListViewModel` to apply the selected filter to the city list.
- Adds unit tests to verify the filter functionality.