### PR TITLE
Enhances city details view and map integration

### DIFF
--- a/Cities/Localizable.xcstrings
+++ b/Cities/Localizable.xcstrings
@@ -34,6 +34,7 @@
       }
     },
     "Country: %@" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -45,6 +46,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "País: %@"
+          }
+        }
+      }
+    },
+    "Country: %@ %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Country: %1$@ %2$@"
           }
         }
       }
@@ -100,6 +111,7 @@
       }
     },
     "Flag: %@" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/Cities/Localizable.xcstrings
+++ b/Cities/Localizable.xcstrings
@@ -17,6 +17,9 @@
         }
       }
     },
+    "Bandera: %@" : {
+
+    },
     "cities_title" : {
       "localizations" : {
         "en" : {
@@ -99,6 +102,9 @@
         }
       }
     },
+    "Latitud: %.4f" : {
+
+    },
     "Lon: %.2f" : {
       "localizations" : {
         "en" : {
@@ -114,6 +120,12 @@
           }
         }
       }
+    },
+    "Longitud: %.4f" : {
+
+    },
+    "País: %@" : {
+
     },
     "progress_loading" : {
       "extractionState" : "manual",
@@ -147,6 +159,9 @@
           }
         }
       }
+    },
+    "Ver en mapa" : {
+
     }
   },
   "version" : "1.0"

--- a/Cities/Localizable.xcstrings
+++ b/Cities/Localizable.xcstrings
@@ -17,9 +17,6 @@
         }
       }
     },
-    "Bandera: %@" : {
-
-    },
     "cities_title" : {
       "localizations" : {
         "en" : {
@@ -32,6 +29,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ciudades"
+          }
+        }
+      }
+    },
+    "Country: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Country: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "País: %@"
           }
         }
       }
@@ -86,6 +99,22 @@
         }
       }
     },
+    "Flag: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flag: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bandera: %@"
+          }
+        }
+      }
+    },
     "Lat: %.2f" : {
       "localizations" : {
         "en" : {
@@ -102,8 +131,21 @@
         }
       }
     },
-    "Latitud: %.4f" : {
-
+    "Latitude: %.4f" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Latitude: %.4f"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Latitud: %.4f"
+          }
+        }
+      }
     },
     "Lon: %.2f" : {
       "localizations" : {
@@ -121,11 +163,37 @@
         }
       }
     },
-    "Longitud: %.4f" : {
-
+    "Longitude: %.4f" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Longitude: %.4f"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Longitud: %.4f"
+          }
+        }
+      }
     },
-    "País: %@" : {
-
+    "Open map" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open map"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar mapa"
+          }
+        }
+      }
     },
     "progress_loading" : {
       "extractionState" : "manual",
@@ -159,9 +227,6 @@
           }
         }
       }
-    },
-    "Ver en mapa" : {
-
     }
   },
   "version" : "1.0"

--- a/Cities/Presentation/Screens/Detail/CityDetailView.swift
+++ b/Cities/Presentation/Screens/Detail/CityDetailView.swift
@@ -1,0 +1,82 @@
+//
+//  CityDetailView.swift
+//  Cities
+//
+//  Created by Manuel Rodríguez Sebastián on 2/7/25.
+//
+
+import SwiftUI
+
+struct CityDetailView: View {
+    @Environment(\.dismiss) private var dismiss
+    
+    let city: CityRenderModel
+
+    var body: some View {
+        if #available(iOS 16.0, *) {
+            contentView
+                .presentationDetents([.fraction(0.4), .medium, .large])
+                .presentationDragIndicator(.visible)
+        } else {
+            contentView
+        }
+    }
+}
+
+private extension CityDetailView {
+    @ViewBuilder
+    var contentView: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            header
+            infoView
+            Spacer()
+            button
+        }
+        .padding()
+    }
+    
+    @ViewBuilder
+    var header: some View {
+        HStack {
+            Text(city.name)
+                .font(.title2)
+                .fontWeight(.semibold)
+            
+            Spacer()
+            
+            Text(city.countryFlag)
+                .font(.largeTitle)
+        }
+    }
+    
+    @ViewBuilder
+    var infoView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("País: \(city.country)")
+            Text("Bandera: \(city.countryFlag)")
+            Text("Latitud: \(city.coordinates.latitude, specifier: "%.4f")")
+            Text("Longitud: \(city.coordinates.longitude, specifier: "%.4f")")
+        }
+        .font(.subheadline)
+        .foregroundStyle(.secondary)
+    }
+    
+    @ViewBuilder
+    var button: some View {
+        HStack {
+            Spacer()
+            Button {
+                dismiss()
+            } label: {
+                Label("Ver en mapa", systemImage: "map")
+                    .padding(.horizontal)
+            }
+            .buttonStyle(.borderedProminent)
+            Spacer()
+        }
+    }
+}
+
+#Preview {
+    CityDetailView(city: .dummy)
+}

--- a/Cities/Presentation/Screens/Detail/CityDetailView.swift
+++ b/Cities/Presentation/Screens/Detail/CityDetailView.swift
@@ -52,10 +52,10 @@ private extension CityDetailView {
     @ViewBuilder
     var infoView: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("País: \(city.country)")
-            Text("Bandera: \(city.countryFlag)")
-            Text("Latitud: \(city.coordinates.latitude, specifier: "%.4f")")
-            Text("Longitud: \(city.coordinates.longitude, specifier: "%.4f")")
+            Text("Country: \(city.country)")
+            Text("Flag: \(city.countryFlag)")
+            Text("Latitude: \(city.coordinates.latitude, specifier: "%.4f")")
+            Text("Longitude: \(city.coordinates.longitude, specifier: "%.4f")")
         }
         .font(.subheadline)
         .foregroundStyle(.secondary)
@@ -68,7 +68,7 @@ private extension CityDetailView {
             Button {
                 dismiss()
             } label: {
-                Label("Ver en mapa", systemImage: "map")
+                Label("Open map", systemImage: "map")
                     .padding(.horizontal)
             }
             .buttonStyle(.borderedProminent)

--- a/Cities/Presentation/Screens/Detail/CityDetailView.swift
+++ b/Cities/Presentation/Screens/Detail/CityDetailView.swift
@@ -15,7 +15,7 @@ struct CityDetailView: View {
     var body: some View {
         if #available(iOS 16.0, *) {
             contentView
-                .presentationDetents([.fraction(0.4), .medium, .large])
+                .presentationDetents([.height(250)])
                 .presentationDragIndicator(.visible)
         } else {
             contentView
@@ -29,7 +29,6 @@ private extension CityDetailView {
         VStack(alignment: .leading, spacing: 16) {
             header
             infoView
-            Spacer()
             button
         }
         .padding()
@@ -37,23 +36,15 @@ private extension CityDetailView {
     
     @ViewBuilder
     var header: some View {
-        HStack {
-            Text(city.name)
-                .font(.title2)
-                .fontWeight(.semibold)
-            
-            Spacer()
-            
-            Text(city.countryFlag)
-                .font(.largeTitle)
-        }
+        Text(city.name)
+            .font(.title2)
+            .fontWeight(.semibold)
     }
     
     @ViewBuilder
     var infoView: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Country: \(city.country)")
-            Text("Flag: \(city.countryFlag)")
+            Text("Country: \(city.country) \(city.countryFlag)")
             Text("Latitude: \(city.coordinates.latitude, specifier: "%.4f")")
             Text("Longitude: \(city.coordinates.longitude, specifier: "%.4f")")
         }

--- a/Cities/Presentation/Screens/List/View/CityListView.swift
+++ b/Cities/Presentation/Screens/List/View/CityListView.swift
@@ -46,9 +46,11 @@ private extension CityListView {
     @ViewBuilder
     var list: some View {
         List(viewModel.filteredCities, id: \.id) { city in
-            CityRowView(city: city) {
-                Task {
-                    await viewModel.toggleFavorite(for: city)
+            NavigationLink(destination: CityMapView(city: city)) {
+                CityRowView(city: city) {
+                    Task {
+                        await viewModel.toggleFavorite(for: city)
+                    }
                 }
             }
         }

--- a/Cities/Presentation/Screens/Map/CityMapView.swift
+++ b/Cities/Presentation/Screens/Map/CityMapView.swift
@@ -1,0 +1,53 @@
+//
+//  CityMapView.swift
+//  Cities
+//
+//  Created by Manuel Rodríguez Sebastián on 2/7/25.
+//
+
+import SwiftUI
+import MapKit
+
+struct CityMapView: View {
+    let city: CityRenderModel
+    
+    @State private var selectedCity: CityRenderModel?
+    
+    var region: MKCoordinateRegion {
+        MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: city.coordinates.latitude, longitude: city.coordinates.longitude),
+            span: MKCoordinateSpan(latitudeDelta: 0.3, longitudeDelta: 0.3)
+        )
+    }
+    
+    var body: some View {
+        Map(coordinateRegion: .constant(region), annotationItems: [AnnotationItem(coordinate: region.center)]) { item in
+            MapAnnotation(coordinate: city.coordinates) {
+                Button(action: {
+                    selectedCity = city
+                }) {
+                    Image(systemName: "mappin.circle.fill")
+                        .font(.title)
+                        .foregroundStyle(.red)
+                        .shadow(radius: 2)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .ignoresSafeArea(edges: .bottom)
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(item: $selectedCity) { city in
+            CityDetailView(city: city)
+        }
+    }
+    
+    struct AnnotationItem: Identifiable {
+        let id = UUID()
+        let coordinate: CLLocationCoordinate2D
+    }
+}
+
+
+#Preview {
+    CityMapView(city: .dummy)
+}


### PR DESCRIPTION
Improves the user experience by providing a detailed view of cities and integrating a map:

- Introduces a new city detail view displaying relevant information such as country, coordinates, and a button to open the map.
- Integrates the city detail view as a sheet presented from the map annotation.
- Adds translations for new labels in both English and Spanish.
- Navigates to the `CityMapView` when a row in the list is tapped.